### PR TITLE
Fix Puppeteer browser launch failure in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,14 @@
 FROM node:20-alpine
+RUN apk add --no-cache \
+    chromium \
+    nss \
+    freetype \
+    harfbuzz \
+    ca-certificates \
+    ttf-freefont
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 WORKDIR /app
 COPY package*.json ./
 RUN npm install --omit=dev


### PR DESCRIPTION
Hi!
Nice app. I've found an issue when running the Dockerfile and I'd like to share the fix for it. 

**Problem**
After building and running the Docker container, the application failed to retrieve FilmAffinity scores with the following error:

```bash
Failed to launch the browser process: spawn /root/.cache/puppeteer/chrome/linux-142.0.7444.61/chrome-linux64/chrome ENOENT
```

**Root Cause**
By default, Puppeteer tries to download and use its own bundled Chromium binary during npm install. However, in an Alpine Linux container:

The downloaded Chromium binary is not compatible with Alpine's musl libc (it's built for glibc)
Even if it were compatible, the binary lacks the necessary system dependencies (like graphics libraries and fonts) that aren't included in the minimal Alpine base image

So this results in Puppeteer looking for Chrome at /root/.cache/puppeteer/chrome/... which either doesn't exist or isn't executable.

**Solution**
The fix involves a few changes to the Dockerfile:

Install system Chromium and dependencies via Alpine's package manager:

```Dockerfile
RUN apk add --no-cache \    chromium \    nss \    freetype \    harfbuzz \    ca-certificates \    ttf-freefont
```

This installs a properly built Chromium for Alpine along with required libraries for rendering (NSS, FreeType, HarfBuzz) and fonts.

Update ENV to skip Puppeteer's Chromium download during npm install and inform the path of Chromium:

```Dockerfile
ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
```

**Testing**
After applying this fix, the container successfully launches Chromium and retrieves FilmAffinity scores as expected.

:hugs: 