### PR TITLE
feat: replace JSON file cache with SQLite persistent storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,7 @@ RECENT_YEARS=2
 # Milliseconds to wait between individual FilmAffinity requests (scraping).
 # Increase to lower scraping load and reduce rate-limit risk.
 REQUEST_DELAY_MS=5000
+ 
+# Path to SQLite DB file used for persistent ratings storage
+# Relative to project root, e.g. `data/ratings.db`
+DB_PATH=data/ratings.db

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .env
 .cache
 data/ratings.json
+data/ratings.db

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## 🚀 Features
 
 * 🎯 Reliable scraping using **Puppeteer + Stealth Plugin**
-* 💾 Daily-generated local cache (`data/ratings.json`)
+* 💾 Persistent SQLite storage (`data/ratings.db`) with in-memory NodeCache layer
 * ⚡ Fast in-memory caching with NodeCache
 * 🔌 Simple REST API endpoint: `/movie?title=...&year=...`
 * 🔗 Direct integration support with Jellyfin API
@@ -97,7 +97,7 @@ docker pull ghcr.io/cruzadera/filmaffinity-scores:latest
 
 ## ⏰ Scheduler service
 
-The `docker-compose.yml` includes a `scheduler` service that performs an initial full library cache population by running `node src/scripts/updateCache.js` on startup, then runs the same update once per day. The scheduler shares the `./data` volume so the generated `data/ratings.json` is persisted and available to the API container.
+The `docker-compose.yml` includes a `scheduler` service that performs an initial full library cache population by running `node src/scripts/updateCache.js` on startup, then runs the same update once per day. The scheduler shares the `./data` volume so the generated `data/ratings.db` is persisted and available to the API container.
 
 You can control the interval with the `SLEEP_SECONDS` environment variable (default `86400` seconds = 24h). To run the scheduler with Docker Compose:
 
@@ -158,6 +158,7 @@ Additional environment variables for the incremental cache updater
 - `RECENT_YEARS`: number — how many years back are considered "recent" (used to pick `RECENT_TTL_DAYS`). Default: `2`.
 - `REQUEST_DELAY_MS`: number — milliseconds to wait between scraping requests to FilmAffinity (helps avoid rate-limits/blocks). Default: `5000`.
 - `SYNC_JELLYFIN_LIMIT`: integer — maximum number of items to process (useful for testing). Default: no limit.
+ - `DB_PATH`: path — filesystem path where the SQLite DB will be stored (default: `data/ratings.db`). Ensure this path is persisted in Docker volumes.
 
 Examples:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "better-sqlite3": "^8.7.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
         "node-cache": "^5.1.2",
@@ -286,6 +287,26 @@
         "bare-path": "^3.0.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/basic-ftp": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
@@ -293,6 +314,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.7.0.tgz",
+      "integrity": "sha512-99jZU4le+f3G6aIl6PmmV0cxUIWqKieHxsiF7G34CVFiE+/UabpYqkU0NJIkY/96mQKikHeBjtR27vFfs5JpEw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -323,6 +375,30 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-crc32": {
@@ -380,6 +456,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/chromium-bidi": {
       "version": "10.5.1",
@@ -548,6 +630,30 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -578,6 +684,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/devtools-protocol": {
@@ -775,6 +890,15 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/express": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
@@ -852,6 +976,12 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -907,6 +1037,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -1011,6 +1147,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -1138,6 +1280,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -1169,6 +1331,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -1383,6 +1551,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1393,6 +1573,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/mitt": {
@@ -1423,10 +1612,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -1445,6 +1646,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-cache": {
@@ -1593,6 +1806,61 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -1881,6 +2149,35 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -2120,6 +2417,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -2188,6 +2530,15 @@
         "text-decoder": "^1.1.0"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -2212,6 +2563,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/tar-fs": {
@@ -2263,6 +2623,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -2307,6 +2679,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "María",
   "license": "ISC",
   "dependencies": {
+    "better-sqlite3": "^8.7.0",
     "dotenv": "^17.2.3",
     "express": "^5.1.0",
     "node-cache": "^5.1.2",

--- a/src/db/sqlite.js
+++ b/src/db/sqlite.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const path = require('path');
+
+function init(dbPath) {
+  const Database = require('better-sqlite3');
+
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new Database(dbPath);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS ratings (
+      key TEXT PRIMARY KEY,
+      title TEXT,
+      year INTEGER,
+      rating REAL,
+      votes INTEGER,
+      url TEXT,
+      last_updated TEXT,
+      raw TEXT
+    );
+  `);
+
+  const getRatingStmt = db.prepare('SELECT * FROM ratings WHERE key = ?');
+  const upsertStmt = db.prepare(`
+    INSERT INTO ratings (key, title, year, rating, votes, url, last_updated, raw)
+    VALUES (@key, @title, @year, @rating, @votes, @url, @last_updated, @raw)
+    ON CONFLICT(key) DO UPDATE SET
+      title=excluded.title,
+      year=excluded.year,
+      rating=excluded.rating,
+      votes=excluded.votes,
+      url=excluded.url,
+      last_updated=excluded.last_updated,
+      raw=excluded.raw;
+  `);
+
+  const getAllStmt = db.prepare('SELECT * FROM ratings');
+
+  return {
+    getRating(key) {
+      return getRatingStmt.get(key);
+    },
+    upsert(r) {
+      const row = {
+        key: r.key,
+        title: r.title || null,
+        year: r.year || null,
+        rating: r.rating || null,
+        votes: r.votes ? Number(r.votes) : null,
+        url: r.url || null,
+        last_updated: r.last_updated || null,
+        raw: r.raw || null,
+      };
+      return upsertStmt.run(row);
+    },
+    getAll() {
+      return getAllStmt.all();
+    },
+    close() {
+      try { db.close(); } catch (e) { /* ignore */ }
+    },
+  };
+}
+
+module.exports = { init };

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 const express = require("express");
-const fs = require("fs");
 const path = require("path");
 const dotenv = require("dotenv");
 const NodeCache = require("node-cache");
 const { getFilmAffinityRating, ScraperError } = require("./scraper/filmaffinity");
 const logger = require("./logging");
+const { init: initDb } = require("./db/sqlite");
 dotenv.config();
 
 const app = express();
@@ -16,7 +16,8 @@ const cache = new NodeCache({
 });
 
 const PORT = process.env.PORT || 8085;
-const CACHE_FILE = path.join(__dirname, "../data/ratings.json");
+const DB_FILE = process.env.DB_PATH || path.join(__dirname, "../data/ratings.db");
+const db = initDb(DB_FILE);
 
 function normalizeTitle(title) {
   return String(title || "")
@@ -34,24 +35,6 @@ function buildCacheKey(title, year) {
   const normalizedTitle = normalizeTitle(title).toLowerCase();
   const normalizedYear = normalizeYear(year);
   return normalizedYear ? `${normalizedTitle}::${normalizedYear}` : normalizedTitle;
-}
-
-function readLocalCache() {
-  if (!fs.existsSync(CACHE_FILE)) {
-    return {};
-  }
-
-  try {
-    return JSON.parse(fs.readFileSync(CACHE_FILE, "utf-8"));
-  } catch (err) {
-    console.error("Error reading local cache:", err.message);
-    return {};
-  }
-}
-
-function writeLocalCache(cacheData) {
-  fs.mkdirSync(path.dirname(CACHE_FILE), { recursive: true });
-  fs.writeFileSync(CACHE_FILE, JSON.stringify(cacheData, null, 2), "utf-8");
 }
 
 function validateMovieQuery(query, requireYear = false) {
@@ -81,24 +64,25 @@ async function handleRatingRequest(req, res, { requireYear = false } = {}) {
 
   const { title, year } = validation;
   const cacheKey = buildCacheKey(title, year);
-  const legacyCacheKey = buildCacheKey(title);
 
   if (cache.has(cacheKey)) {
     logger.info(`In-memory cache hit: ${title}${year ? ` (${year})` : ""}`);
     return res.json(cache.get(cacheKey));
   }
 
-  const localCache = readLocalCache();
-  const cachedEntry = localCache[cacheKey];
-  const legacyEntry = !year ? null : localCache[legacyCacheKey];
-  const cacheHit =
-    cachedEntry ||
-    (legacyEntry && (!legacyEntry.year || String(legacyEntry.year) === year) ? legacyEntry : null);
-
-  if (cacheHit) {
-    logger.info(`File cache hit: ${title}${year ? ` (${year})` : ""}`);
-    cache.set(cacheKey, cacheHit);
-    return res.json(cacheHit);
+  // DB lookup (includes fallback to title-only key for migrated entries)
+  let dbEntry = db.getRating(cacheKey);
+  if (!dbEntry && year) {
+    const legacyEntry = db.getRating(buildCacheKey(title));
+    if (legacyEntry && (!legacyEntry.year || String(legacyEntry.year) === year)) dbEntry = legacyEntry;
+  }
+  if (dbEntry) {
+    const hitData = dbEntry.raw
+      ? JSON.parse(dbEntry.raw)
+      : { title: dbEntry.title, year: dbEntry.year, rating: dbEntry.rating, votes: dbEntry.votes, url: dbEntry.url };
+    logger.info(`DB cache hit: ${title}${year ? ` (${year})` : ""}`);
+    cache.set(cacheKey, hitData);
+    return res.json(hitData);
   }
 
   logger.info(`Fetching FilmAffinity rating for: ${title}${year ? ` (${year})` : ""}`);
@@ -112,8 +96,16 @@ async function handleRatingRequest(req, res, { requireYear = false } = {}) {
     }
 
     cache.set(cacheKey, data);
-    localCache[cacheKey] = data;
-    writeLocalCache(localCache);
+    db.upsert({
+      key: cacheKey,
+      title: data.title || title,
+      year: data.year || year || null,
+      rating: data.rating,
+      votes: data.votes,
+      url: data.url,
+      last_updated: new Date().toISOString(),
+      raw: JSON.stringify(data),
+    });
 
     logger.info(`Stored in cache: ${title}${year ? ` (${year})` : ""} (${data.rating})`);
     return res.json(data);

--- a/src/scripts/cacheUtils.js
+++ b/src/scripts/cacheUtils.js
@@ -17,8 +17,24 @@ function isStale(entry, year, opts = {}) {
   return daysSince(entry.last_updated) > ttl;
 }
 
+function normalizeTitle(title) {
+  return String(title || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim();
+}
+
+function buildCacheKey(title, year) {
+  const normalizedTitle = normalizeTitle(title);
+  const normalizedYear = String(year || "").trim();
+  return normalizedYear ? `${normalizedTitle}::${normalizedYear}` : normalizedTitle;
+}
+
 module.exports = {
   daysSince,
   computeTTLForYear,
   isStale,
+  normalizeTitle,
+  buildCacheKey,
 };

--- a/src/scripts/updateCache.js
+++ b/src/scripts/updateCache.js
@@ -1,11 +1,13 @@
 const fs = require("fs");
 const path = require("path");
+const { init: initDb } = require("../db/sqlite");
 const dotenv = require("dotenv");
 const { getFilmAffinityRating } = require("../services/filmaffinity");
 
 dotenv.config();
 
 const OUTPUT_FILE = path.join(__dirname, "../../data/ratings.json");
+const DEFAULT_DB_PATH = path.join(__dirname, "../../data/ratings.db");
 const REQUEST_DELAY_MS = Number(process.env.REQUEST_DELAY_MS || 5000);
 const JELLYFIN_URL = (
   process.env.JELLYFIN_BASE_URL || process.env.JELLYFIN_URL || "http://localhost:8096"
@@ -23,29 +25,11 @@ const CACHE_TTL_DAYS = process.env.CACHE_TTL_DAYS
 const RECENT_TTL_DAYS = Number(process.env.RECENT_TTL_DAYS || 7);
 const RECENT_YEARS = Number(process.env.RECENT_YEARS || 2);
 
-const { isStale } = require("./cacheUtils");
+const { isStale, buildCacheKey } = require("./cacheUtils");
 
 if (!JELLYFIN_API_KEY) {
   console.error("Missing Jellyfin API key in .env (JELLYFIN_API_KEY)");
   process.exit(1);
-}
-
-function daysSince(iso) {
-  return (Date.now() - new Date(iso).getTime()) / (1000 * 60 * 60 * 24);
-}
-
-function computeTTLForYear(year) {
-  if (!year || isNaN(Number(year))) return CACHE_TTL_DAYS;
-  const currentYear = new Date().getFullYear();
-  if (Number(year) >= currentYear - RECENT_YEARS) return RECENT_TTL_DAYS;
-  return CACHE_TTL_DAYS;
-}
-
-function isStale(entry, year) {
-  if (!entry) return true;
-  if (!entry.last_updated) return true;
-  const ttl = computeTTLForYear(year);
-  return daysSince(entry.last_updated) > ttl;
 }
 
 async function fetchJellyfin(pathname, searchParams = {}, authMode = "header") {
@@ -110,6 +94,7 @@ async function fetchTitlesFromJellyfin() {
 }
 
 function loadExistingCache() {
+  // Legacy JSON loader; kept for migration. Prefer DB when available.
   try {
     if (!fs.existsSync(OUTPUT_FILE)) return {};
     const raw = fs.readFileSync(OUTPUT_FILE, "utf-8");
@@ -122,7 +107,6 @@ function loadExistingCache() {
 
 async function updateCache() {
   console.log("Starting incremental FilmAffinity cache update...");
-
   let titles = await fetchTitlesFromJellyfin();
   // Optionally limit number of titles to process (useful for testing)
   const MAX_TITLES = process.env.SYNC_JELLYFIN_LIMIT ? Number(process.env.SYNC_JELLYFIN_LIMIT) : undefined;
@@ -130,10 +114,25 @@ async function updateCache() {
     console.log(`Limiting titles to first ${MAX_TITLES} for this run (testing mode)`);
     titles = titles.slice(0, MAX_TITLES);
   }
-  const existing = loadExistingCache();
+  // Initialize DB
+  const DB_PATH = process.env.DB_PATH || DEFAULT_DB_PATH;
+  const db = initDb(DB_PATH);
 
-  // Normalize keys to lowercase for consistent lookup
-  const cache = { ...existing };
+  // Migrate JSON -> SQLite if DB empty and JSON present
+  try {
+    const rows = db.getAll();
+    if (rows.length === 0 && fs.existsSync(OUTPUT_FILE)) {
+      console.log("Migrating existing JSON cache into SQLite DB...");
+      const existing = loadExistingCache();
+      for (const [, v] of Object.entries(existing)) {
+        const key = buildCacheKey(v.title, v.year);
+        db.upsert({ key, title: v.title, year: v.year, rating: v.rating, votes: v.votes, url: v.url, last_updated: v.last_updated, raw: JSON.stringify(v) });
+      }
+      console.log("Migration complete.");
+    }
+  } catch (e) {
+    console.warn("Migration check failed:", e.message);
+  }
 
   // Sort recent movies first (prioritize updates)
   titles.sort((a, b) => (Number(b.year || 0) - Number(a.year || 0)));
@@ -145,8 +144,8 @@ async function updateCache() {
   let failed = 0;
 
   for (const { title, year } of titles) {
-    const key = title.toLowerCase();
-    const entry = cache[key];
+    const key = buildCacheKey(title, year);
+    const entry = db.getRating(key);
 
     if (!isStale(entry, year, { cacheTTL: CACHE_TTL_DAYS, recentTTL: RECENT_TTL_DAYS, recentYears: RECENT_YEARS })) {
       skipped++;
@@ -160,12 +159,18 @@ async function updateCache() {
     try {
       const data = await getFilmAffinityRating(title);
       if (data && data.rating) {
-        cache[key] = {
-          ...data,
-          title, // original title casing
+        const now = new Date().toISOString();
+        const row = {
+          key,
+          title,
           year: year || null,
-          last_updated: new Date().toISOString(),
+          rating: data.rating,
+          votes: data.votes || null,
+          url: data.url || null,
+          last_updated: now,
+          raw: JSON.stringify(data),
         };
+        db.upsert(row);
         updated++;
         console.log(`Updated: ${title} => ${data.rating}`);
       } else {
@@ -180,18 +185,7 @@ async function updateCache() {
     await new Promise((r) => setTimeout(r, REQUEST_DELAY_MS));
   }
 
-  // Persist cache atomically
-  try {
-    fs.mkdirSync(path.dirname(OUTPUT_FILE), { recursive: true });
-    const tmp = `${OUTPUT_FILE}.tmp`;
-    fs.writeFileSync(tmp, JSON.stringify(cache, null, 2), "utf-8");
-    fs.renameSync(tmp, OUTPUT_FILE);
-    console.log(`Cache written to ${OUTPUT_FILE}`);
-  } catch (err) {
-    console.error("Failed to write cache:", err.message);
-    process.exit(1);
-  }
-
+  db.close();
   console.log(`Summary: total=${total}, toUpdate=${toUpdate}, updated=${updated}, skipped=${skipped}, failed=${failed}`);
 }
 

--- a/test/movie.test.js
+++ b/test/movie.test.js
@@ -1,27 +1,23 @@
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const http = require("node:http");
+const os = require("node:os");
 const path = require("node:path");
 const { after, test } = require("node:test");
+const { init: initDb } = require("../src/db/sqlite");
 
 const repoRoot = path.join(__dirname, "..");
-const cacheFile = path.join(repoRoot, "data", "ratings.json");
 const indexPath = path.join(repoRoot, "src", "index.js");
 const scraperPath = path.join(repoRoot, "src", "scraper", "filmaffinity.js");
 
-const originalCacheExists = fs.existsSync(cacheFile);
-const originalCacheContent = originalCacheExists ? fs.readFileSync(cacheFile, "utf-8") : null;
+// Use an isolated temp DB per test run so tests never interfere with real data
+const tmpDbPath = path.join(os.tmpdir(), `ratings-test-${Date.now()}.db`);
+process.env.DB_PATH = tmpDbPath;
 
-function restoreCacheFile() {
-  if (originalCacheExists) {
-    fs.mkdirSync(path.dirname(cacheFile), { recursive: true });
-    fs.writeFileSync(cacheFile, originalCacheContent, "utf-8");
-    return;
-  }
-
-  if (fs.existsSync(cacheFile)) {
-    fs.unlinkSync(cacheFile);
-  }
+function resetDb() {
+  if (fs.existsSync(tmpDbPath)) fs.unlinkSync(tmpDbPath);
+  // Clear module cache so index.js re-initialises the DB
+  delete require.cache[indexPath];
 }
 
 function loadApp(mockGetFilmAffinityRating) {
@@ -54,9 +50,9 @@ function startServer(app) {
 }
 
 after(() => {
-  restoreCacheFile();
   delete require.cache[indexPath];
   delete require.cache[scraperPath];
+  if (fs.existsSync(tmpDbPath)) fs.unlinkSync(tmpDbPath);
 });
 
 test('GET /movie returns 400 when "title" is missing', async (t) => {
@@ -108,7 +104,7 @@ test('GET /movie returns 400 when "year" is invalid', async (t) => {
 });
 
 test("GET /movie returns FilmAffinity data for valid input", async (t) => {
-  restoreCacheFile();
+  resetDb();
 
   const expectedPayload = {
     title: "Alien",
@@ -127,7 +123,7 @@ test("GET /movie returns FilmAffinity data for valid input", async (t) => {
 
   t.after(() => {
     server.close();
-    restoreCacheFile();
+    resetDb();
   });
 
   const response = await fetch(`${baseUrl}/movie?title=Alien&year=1979`);
@@ -135,12 +131,15 @@ test("GET /movie returns FilmAffinity data for valid input", async (t) => {
   assert.equal(response.status, 200);
   assert.deepEqual(await response.json(), expectedPayload);
 
-  const cacheContent = JSON.parse(fs.readFileSync(cacheFile, "utf-8"));
-  assert.deepEqual(cacheContent["alien::1979"], expectedPayload);
+  const verifyDb = initDb(tmpDbPath);
+  const row = verifyDb.getRating("alien::1979");
+  verifyDb.close();
+  assert.ok(row, "DB entry should exist for alien::1979");
+  assert.deepEqual(JSON.parse(row.raw), expectedPayload);
 });
 
 test("GET /movie normalizes title input before matching", async (t) => {
-  restoreCacheFile();
+  resetDb();
 
   const expectedPayload = {
     title: "Amelie",
@@ -159,7 +158,7 @@ test("GET /movie normalizes title input before matching", async (t) => {
 
   t.after(() => {
     server.close();
-    restoreCacheFile();
+    resetDb();
   });
 
   const response = await fetch(`${baseUrl}/movie?title=%20%20Am%C3%A9lie%20%20&year=2001`);
@@ -167,12 +166,15 @@ test("GET /movie normalizes title input before matching", async (t) => {
   assert.equal(response.status, 200);
   assert.deepEqual(await response.json(), expectedPayload);
 
-  const cacheContent = JSON.parse(fs.readFileSync(cacheFile, "utf-8"));
-  assert.deepEqual(cacheContent["amelie::2001"], expectedPayload);
+  const verifyDb = initDb(tmpDbPath);
+  const row = verifyDb.getRating("amelie::2001");
+  verifyDb.close();
+  assert.ok(row, "DB entry should exist for amelie::2001");
+  assert.deepEqual(JSON.parse(row.raw), expectedPayload);
 });
 
 test("GET /movie returns 404 when the scraper finds no results", async (t) => {
-  restoreCacheFile();
+  resetDb();
 
   const app = loadApp(async (title, year) => {
     assert.equal(title, "unknown movie");
@@ -183,7 +185,7 @@ test("GET /movie returns 404 when the scraper finds no results", async (t) => {
 
   t.after(() => {
     server.close();
-    restoreCacheFile();
+    resetDb();
   });
 
   const response = await fetch(`${baseUrl}/movie?title=Unknown%20Movie&year=2099`);
@@ -195,7 +197,7 @@ test("GET /movie returns 404 when the scraper finds no results", async (t) => {
 });
 
 test("GET /movie returns 502 when the scraper errors", async (t) => {
-  restoreCacheFile();
+  resetDb();
 
   const app = loadApp(async (title, year) => {
     assert.equal(title, "some title");
@@ -208,7 +210,7 @@ test("GET /movie returns 502 when the scraper errors", async (t) => {
 
   t.after(() => {
     server.close();
-    restoreCacheFile();
+    resetDb();
   });
 
   const response = await fetch(`${baseUrl}/movie?title=Some%20Title&year=2000`);


### PR DESCRIPTION
- Add src/db/sqlite.js with better-sqlite3 repository abstraction
- Add src/scripts/cacheUtils.js with shared utility functions
  (daysSince, computeTTLForYear, isStale, normalizeTitle, buildCacheKey)
- Refactor src/scripts/updateCache.js to write incrementally to SQLite
  with one-time migration from ratings.json if DB is empty
- Replace JSON read/write layer in src/index.js with SQLite lookups
- Update test/movie.test.js to use isolated temp SQLite DB per test run
- Add data/ratings.db to .gitignore
- Document DB_PATH, RECENT_TTL_DAYS, RECENT_YEARS env vars in README 
Resolve #38 